### PR TITLE
Scrollytelling fixes

### DIFF
--- a/css/blocks/_scrolly-image.scss
+++ b/css/blocks/_scrolly-image.scss
@@ -10,6 +10,10 @@
 		margin: 30px 0;
 	}
 
+	@include breakpoint(lg) {
+		width: 860px;
+	}
+
 	.acf-block-preview & {
 		height: 600px;
 		overflow: hidden;
@@ -85,6 +89,7 @@
 
 	.caption {
 		position: relative;
+		width: 100%;
 		height: calc(var(--vh, 1vh) * 100);
 		transform: translateY(calc(var(--vh, 1vh) * -100));
 
@@ -107,11 +112,16 @@
 		transform: translateY(-50%) translateX(-50%);
 		width: 300px;
 
+		p {
+			margin-top: 5px;
+		}
+
 		> *:first-child {
 			margin-top: 0;
 		}
 
 		@include breakpoint(md) {
+			left: auto;
 			right: 0;
 			transform: translateY(-50%) translateX(0);
 		}

--- a/css/blocks/_scrolly-image.scss
+++ b/css/blocks/_scrolly-image.scss
@@ -120,6 +120,12 @@
 			margin-top: 0;
 		}
 
+		figcaption {
+			font-size: 16px;
+			line-height: 20px;
+			color: #999;
+		}
+
 		@include breakpoint(md) {
 			left: auto;
 			right: 0;

--- a/functions.php
+++ b/functions.php
@@ -24,6 +24,7 @@ class Phragmites {
 		$this->setup_image_sizes();
 		$this->setup_redirects();
 		$this->setup_social_cards();
+		$this->setup_caption_shortcode();
 	}
 
 	function setup_theme_supports() {
@@ -34,7 +35,7 @@ class Phragmites {
 			add_theme_support('disable-custom-font-sizes');
 			add_theme_support('align-wide');
 			add_theme_support('responsive-embeds');
-			add_theme_support('html5', ['style','script',]);
+			add_theme_support('html5', ['style', 'script', 'caption']);
 		});
 	}
 
@@ -203,6 +204,19 @@ class Phragmites {
 <meta name="twitter:description" content="{$this->meta['description']}">
 END;
 		});
+	}
+
+	function setup_caption_shortcode() {
+		add_filter('img_caption_shortcode', function($output, $attr, $content) {
+			return <<<END
+				<figure class="wp-caption align{$attr['align']}">
+					$content
+					<figcaption>
+						{$attr['caption']}
+					</figcaption>
+				</figure>
+END;
+		}, 10, 3);
 	}
 
 	function social_card_defaults() {


### PR DESCRIPTION
Don't overlap the caption with the image on large screen widths. Update how media with captions works, and make sure it doesn't look bad in the scrolly caption.