### PR TITLE
Make sure the caption is above the image

### DIFF
--- a/css/blocks/_scrolly-image.scss
+++ b/css/blocks/_scrolly-image.scss
@@ -111,6 +111,7 @@
 		padding: 15px;
 		transform: translateY(-50%) translateX(-50%);
 		width: 300px;
+		z-index: 1;
 
 		&.empty {
 			visibility: hidden;


### PR DESCRIPTION
Set an explicit z-index on the caption element so it never shows up behind the image.