### PR TITLE
Fix sass warnings

### DIFF
--- a/css/_layout.scss
+++ b/css/_layout.scss
@@ -1,7 +1,9 @@
 @use 'variables' as *;
 
 @mixin full-height {
-	min-height: calc(100vh - 3px);
+	& {
+		min-height: calc(100vh - 3px);
+	}
 
 	body.admin-bar & {
 		min-height: calc(100vh - 32px);

--- a/css/blocks/_intro.scss
+++ b/css/blocks/_intro.scss
@@ -2,9 +2,6 @@
 @use '../layout' as *;
 
 .intro-block {
-	@include section-block;
-	@include full-height;
-
 	position: relative;
 	background-size: cover;
 	background-position: center center;
@@ -13,6 +10,9 @@
 	letter-spacing: 0.05em;
 	line-height: 1.8;
 	font-size: 16px;
+
+	@include section-block;
+	@include full-height;
 
 	.container {
 		position: absolute;

--- a/css/blocks/_videos.scss
+++ b/css/blocks/_videos.scss
@@ -6,9 +6,10 @@ body.post-type-archive-video, body.single-video {
 }
 
 .videos-block {
-	@include section-block;
 	border-color: #fc0;
 	background-color: #222;
+
+	@include section-block;
 
 	a,
 	.breadcrumbs h2 a {

--- a/css/pages/_project.scss
+++ b/css/pages/_project.scss
@@ -1,8 +1,8 @@
 @use '../variables' as *;
 
 .project-page {
-	@include section-block;
 	background-color: #fff;
+	@include section-block;
 
 	.container {
 		margin: 0 auto;


### PR DESCRIPTION
Fix these warnings from `npm run build`:

> Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
> 
> More info: https://sass-lang.com/d/mixed-decls
